### PR TITLE
Disable "curly" tsling setting

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
     "no-string-throw": true,
     "no-unused-expression": true,
     "no-duplicate-variable": true,
-    "curly": true,
+    "curly": false,
     "class-name": true,
     "semicolon": [true, "always"],
     "triple-equals": true


### PR DESCRIPTION
Disable "curly" tsling setting to make current state of code comply to TSLint rules. It's now identical to the settings of the `abracadabra` repository