### PR TITLE
Create switch cases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
     "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off",
-  "typescript.tsdk": "/Users/espeon/Development/github/nicoespeon/hocus-pocus/node_modules/typescript/lib"
+  "typescript.tsc.autoDetect": "off"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  "typescript.tsdk": "/Users/espeon/Development/github/nicoespeon/hocus-pocus/node_modules/typescript/lib"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- We moved the 🔮 emoji at the end of the Quick Fix title for accessibility. Now you can type the first character of the title to select it with your keyboard!
+
 ## [1.5.0] - 2020-05-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **(New Feature)** Create Switch Cases
+
 ### Changed
 
 - We moved the 🔮 emoji at the end of the Quick Fix title for accessibility. Now you can type the first character of the title to select it with your keyboard!

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Just like "Create Function", this can be very useful if you tend to write class 
 
 ![][demo-create-class]
 
+### Create Switch Cases
+
+Create all missing cases of a switch statement made over an union type or an enum.
+
+Very convenient when you need to generate a switch statement to handle each scenario. If some cases are already present, it will complete the remaining ones.
+
+![][demo-create-switch-cases]
+
 ## Release Notes
 
 [Have a look at our CHANGELOG][changelog] to get the details of all changes between versions.
@@ -121,6 +129,7 @@ Contributions of any kind are welcome!
 [demo-create-function]: https://github.com/nicoespeon/hocus-pocus/blob/master/assets/features/create-function.gif?raw=true
 [demo-create-variable]: https://github.com/nicoespeon/hocus-pocus/blob/master/assets/features/create-variable.gif?raw=true
 [demo-create-class]: https://github.com/nicoespeon/hocus-pocus/blob/master/assets/features/create-class.gif?raw=true
+[demo-create-switch-cases]: https://github.com/nicoespeon/hocus-pocus/blob/master/assets/features/create-switch-cases.gif?raw=true
 
 <!-- Logo -->
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "onCommand:hocusPocus.createFunction",
     "onCommand:hocusPocus.createFunctionWithTypes",
     "onCommand:hocusPocus.createVariable",
+    "onCommand:hocusPocus.createClass",
+    "onCommand:hocusPocus.createSwitchCases",
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
@@ -99,6 +101,11 @@
       {
         "command": "hocusPocus.createClass",
         "title": "Create Class",
+        "category": "Hocus Pocus"
+      },
+      {
+        "command": "hocusPocus.createSwitchCases",
+        "title": "Create Switch Cases",
         "category": "Hocus Pocus"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@babel/parser": "7.7.5",
     "@babel/traverse": "7.7.4",
+    "@babel/generator": "7.7.4",
     "@typescript/vfs": "1.0.0",
     "typescript": "3.8.3"
   },

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,6 +1,7 @@
 import { parse } from "@babel/parser";
 import traverse, { TraverseOptions, Scope } from "@babel/traverse";
 import { NodePath } from "@babel/traverse";
+import generate from "@babel/generator";
 import * as t from "@babel/types";
 
 import { Code } from "./editor";
@@ -10,7 +11,7 @@ export { NodePath } from "@babel/traverse";
 export { Selection, Position };
 export { Selectable, SelectableNode, SelectablePath };
 export { isSelectablePath, isSelectableNode };
-export { traverseCode };
+export { traverseCode, print };
 export { isDeclared, isMemberExpressionProperty };
 export {
   topLevelAncestor,
@@ -76,6 +77,11 @@ function traverseCode(code: Code, options: TraverseOptions) {
     }),
     options
   );
+}
+
+function print(ast: t.Node | null): string {
+  if (!ast) return "";
+  return generate(ast).code;
 }
 
 function isDeclared(id: t.Identifier, path: NodePath): boolean {

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -202,6 +202,23 @@ function bla(value: Values) {
 it("should resolve literal values of an enum", () => {
   const code = `enum Values {
   One,
+  Two
+};
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(5, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getLiteralValuesAt(position);
+
+  expect(type).toEqual([`Values.One`, `Values.Two`]);
+});
+
+it("should resolve literal values of an enum with aliases", () => {
+  const code = `enum Values {
+  One = 1,
   Two = "two"
 };
 

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -111,6 +111,20 @@ function bla() {
   expect(type).toBe(`Bla`);
 });
 
+it("should infer type of a union string", () => {
+  const code = `type Values = "one" | "two";
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(3, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getTypeAt(position);
+
+  expect(type).toBe(`Values`);
+});
+
 it("should return any if code is empty", () => {
   const code = ``;
   const position = new Position(0, 0);

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -199,5 +199,19 @@ function bla(value: Values) {
   expect(type).toEqual([`"one"`, `2`, `true`, `"four"`, `"five"`]);
 });
 
-// TODO: test for enum
-// TODO: test for mix of enums and unions mixed
+it("should resolve literal values of an enum", () => {
+  const code = `enum Values {
+  One,
+  Two = "two"
+};
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(5, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getLiteralValuesAt(position);
+
+  expect(type).toEqual([`Values.One`, `Values.Two`]);
+});

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -154,3 +154,22 @@ it("should return any if position is not on an identifier", () => {
 
   expect(type).toBe("any");
 });
+
+it("should resolve literal values of a union string", () => {
+  const code = `type Values = "one" | "two";
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(3, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getLiteralValuesAt(position);
+
+  expect(type).toEqual([`"one"`, `"two"`]);
+});
+
+// TODO: test for nested union things
+// TODO: test for mix of types in union
+// TODO: test for enum
+// TODO: test for mix of enums and unions mixed

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -215,3 +215,21 @@ function bla(value: Values) {
 
   expect(type).toEqual([`Values.One`, `Values.Two`]);
 });
+
+it("should work if there are other type declarations before", () => {
+  const code = `type Others = "one" | "two";
+enum Values {
+  One,
+  Two = "two"
+};
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(6, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getLiteralValuesAt(position);
+
+  expect(type).toEqual([`Values.One`, `Values.Two`]);
+});

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -169,7 +169,21 @@ function bla(value: Values) {
   expect(type).toEqual([`"one"`, `"two"`]);
 });
 
-// TODO: test for nested union things
+it("should resolve literal values of a nested union string", () => {
+  const code = `type Values = "one" | "two" | OtherValues | "five";
+type OtherValues = "three" | "four";
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(4, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getLiteralValuesAt(position);
+
+  expect(type).toEqual([`"one"`, `"two"`, `"three"`, `"four"`, `"five"`]);
+});
+
 // TODO: test for mix of types in union
 // TODO: test for enum
 // TODO: test for mix of enums and unions mixed

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -233,6 +233,23 @@ function bla(value: Values) {
   expect(type).toEqual([`Values.One`, `Values.Two`]);
 });
 
+it("should resolve literal values of an enum with trailing comma", () => {
+  const code = `enum Values {
+  One = 1,
+  Two,
+};
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(5, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getLiteralValuesAt(position);
+
+  expect(type).toEqual([`Values.One`, `Values.Two`]);
+});
+
 it("should work if there are other type declarations before", () => {
   const code = `type Others = "one" | "two";
 enum Values {

--- a/src/create-function-with-types/type-checker.test.ts
+++ b/src/create-function-with-types/type-checker.test.ts
@@ -184,6 +184,20 @@ function bla(value: Values) {
   expect(type).toEqual([`"one"`, `"two"`, `"three"`, `"four"`, `"five"`]);
 });
 
-// TODO: test for mix of types in union
+it("should resolve mixed literal values", () => {
+  const code = `type Values = "one" | 2 | OtherValues | "five";
+type OtherValues = true | "four";
+
+function bla(value: Values) {
+  doSomething(value);
+}`;
+  const position = new Position(4, 15);
+  const typeChecker = new TypeChecker(code);
+
+  const type = typeChecker.getLiteralValuesAt(position);
+
+  expect(type).toEqual([`"one"`, `2`, `true`, `"four"`, `"five"`]);
+});
+
 // TODO: test for enum
 // TODO: test for mix of enums and unions mixed

--- a/src/create-function-with-types/type-checker.ts
+++ b/src/create-function-with-types/type-checker.ts
@@ -146,7 +146,10 @@ export class TypeChecker {
 
     if (is_enum_body) {
       const [, enumName] =
-        node.parent.getFullText().match(/^enum (\w+) /) || [];
+        node.parent
+          .getFullText()
+          .trim()
+          .match(/^enum (\w+) /) || [];
       if (!enumName) return values;
 
       return values.concat(

--- a/src/create-function-with-types/type-checker.ts
+++ b/src/create-function-with-types/type-checker.ts
@@ -129,7 +129,9 @@ export class TypeChecker {
     typeChecker: ts.TypeChecker,
     node: ts.Node
   ): ts.Declaration | undefined {
-    return typeChecker.getTypeAtLocation(node).aliasSymbol?.declarations[0];
+    const type = typeChecker.getTypeAtLocation(node);
+    const symbol = type.aliasSymbol || type.symbol;
+    return symbol.declarations[0];
   }
 
   private resolveLiteralValues(

--- a/src/create-function-with-types/type-checker.ts
+++ b/src/create-function-with-types/type-checker.ts
@@ -187,7 +187,7 @@ export class TypeChecker {
     program: ts.Program
   ): ts.Node | undefined {
     try {
-      // @ts-expect-error Internal method
+      // @ts-ignore Internal method
       return ts.getTouchingPropertyName(
         program.getSourceFile(this.fileName),
         position.value

--- a/src/create-function-with-types/type-checker.ts
+++ b/src/create-function-with-types/type-checker.ts
@@ -139,9 +139,24 @@ export class TypeChecker {
   ): LiteralValue[] {
     const is_literal = node.kind === 187;
     const is_identifier = node.kind === 75;
-    const parent_is_type_declaration = node.parent.kind === 247;
+    const is_enum_body = node.kind === 323 && node.parent.kind === 248;
+    const parent_is_type_declaration = [247, 248].includes(node.parent.kind);
 
     if (is_literal) return values.concat(node.getText());
+
+    if (is_enum_body) {
+      const [, enumName] =
+        node.parent.getFullText().match(/^enum (\w+) /) || [];
+      if (!enumName) return values;
+
+      return values.concat(
+        node
+          .getFullText()
+          .split(",")
+          .map(text => text.split("=")[0].trim())
+          .map(enumValue => `${enumName}.${enumValue}`)
+      );
+    }
 
     if (is_identifier && !parent_is_type_declaration) {
       const firstDeclaration = getFirstDeclaration(node);

--- a/src/create-function-with-types/type-checker.ts
+++ b/src/create-function-with-types/type-checker.ts
@@ -157,6 +157,7 @@ export class TypeChecker {
       return values.concat(
         node
           .getFullText()
+          .replace(/,$/, "")
           .split(",")
           .map(text => text.split("=")[0].trim())
           .map(enumValue => `${enumName}.${enumValue}`)

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -1,0 +1,26 @@
+import { createSwitchCases } from "./create-switch-cases";
+import { Selection, Position } from "../editor";
+import { createShouldUpdateCodeFor } from "../test-helpers";
+
+const shouldUpdateCodeFor = createShouldUpdateCodeFor(createSwitchCases);
+
+it("with an union string", () => {
+  shouldUpdateCodeFor({
+    code: `type Values = "one" | "two" | "three";
+
+function doSomething(value: Values) {
+  switch (value) {
+
+  }
+}`,
+    selection: Selection.cursorAt(4, 0),
+    expectedSnippet: {
+      code: `
+    case "one":
+    case "two":
+    case "three":`,
+      position: new Position(4, 0),
+      name: "TODO: find a name"
+    }
+  });
+});

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -24,3 +24,28 @@ function doSomething(value: Values) {
     }
   });
 });
+
+it("with an enum", () => {
+  shouldUpdateCodeFor({
+    code: `enum Values {
+  One = "one",
+  Two = "two",
+  Three = "three"
+}
+
+function doSomething(value: Values) {
+  switch (value) {
+
+  }
+}`,
+    selection: Selection.cursorAt(8, 0),
+    expectedSnippet: {
+      code: `
+    case Values.One:$1
+    case Values.Two:$2
+    case Values.Three:$3`,
+      position: new Position(8, 0),
+      name: "Create all cases"
+    }
+  });
+});

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -52,6 +52,26 @@ function doSomething(value: Values) {
   });
 });
 
+it("with an one-line switch", () => {
+  shouldUpdateCodeFor({
+    code: `type Values = "one" | "two" | "three";
+
+function doSomething(value: Values) {
+  switch (value) {}
+}`,
+    selection: Selection.cursorAt(3, 18),
+    expectedSnippet: {
+      code: `
+    case "one":$1
+    case "two":$2
+    case "three":$3
+  `,
+      position: new Position(3, 18),
+      name: "Create all cases"
+    }
+  });
+});
+
 it("with an any", () => {
   shouldNotUpdateCodeFor({
     code: `function doSomething(value: any) {

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -20,7 +20,7 @@ function doSomething(value: Values) {
     case "two":
     case "three":`,
       position: new Position(4, 0),
-      name: "TODO: find a name"
+      name: "Create all cases"
     }
   });
 });

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -19,8 +19,7 @@ function doSomething(value: Values) {
 }`,
     selection: Selection.cursorAt(4, 0),
     expectedSnippet: {
-      code: `
-    case "one":$1
+      code: `case "one":$1
     case "two":$2
     case "three":$3`,
       position: new Position(4, 0),
@@ -44,8 +43,7 @@ function doSomething(value: Values) {
 }`,
     selection: Selection.cursorAt(8, 0),
     expectedSnippet: {
-      code: `
-    case Values.One:$1
+      code: `case Values.One:$1
     case Values.Two:$2
     case Values.Three:$3`,
       position: new Position(8, 0),

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -87,6 +87,31 @@ function doSomething(value: Values) {
   });
 });
 
+it("with existing cases", () => {
+  shouldUpdateCodeFor({
+    code: `type Values = "one" | "two" | "three";
+
+function doSomething(value: Values) {
+  switch (value) {
+    case "one":
+      doSomething();
+      break;
+
+    case "three":
+      break;
+  }
+}`,
+    selection: Selection.cursorAt(4, 0),
+    expectedSnippet: {
+      code: `    case "two":
+      $1
+`,
+      position: new Position(10, 0),
+      name: "Create all cases"
+    }
+  });
+});
+
 it("with an any", () => {
   shouldNotUpdateCodeFor({
     code: `function doSomething(value: any) {

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -1,8 +1,12 @@
 import { createSwitchCases } from "./create-switch-cases";
 import { Selection, Position } from "../editor";
-import { createShouldUpdateCodeFor } from "../test-helpers";
+import {
+  createShouldUpdateCodeFor,
+  createShouldNotUpdateCodeFor
+} from "../test-helpers";
 
 const shouldUpdateCodeFor = createShouldUpdateCodeFor(createSwitchCases);
+const shouldNotUpdateCodeFor = createShouldNotUpdateCodeFor(createSwitchCases);
 
 it("with an union string", () => {
   shouldUpdateCodeFor({
@@ -47,5 +51,16 @@ function doSomething(value: Values) {
       position: new Position(8, 0),
       name: "Create all cases"
     }
+  });
+});
+
+it("with an any", () => {
+  shouldNotUpdateCodeFor({
+    code: `function doSomething(value: any) {
+  switch (value) {
+
+  }
+}`,
+    selection: Selection.cursorAt(2, 0)
   });
 });

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -16,9 +16,9 @@ function doSomething(value: Values) {
     selection: Selection.cursorAt(4, 0),
     expectedSnippet: {
       code: `
-    case "one":
-    case "two":
-    case "three":`,
+    case "one":$1
+    case "two":$2
+    case "three":$3`,
       position: new Position(4, 0),
       name: "Create all cases"
     }

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -19,7 +19,7 @@ function doSomething(value: Values) {
 }`,
     selection: Selection.cursorAt(4, 0),
     expectedSnippet: {
-      code: `case "one":
+      code: `    case "one":
       $1
 
     case "two":
@@ -48,7 +48,7 @@ function doSomething(value: Values) {
 }`,
     selection: Selection.cursorAt(8, 0),
     expectedSnippet: {
-      code: `case Values.One:
+      code: `    case Values.One:
       $1
 
     case Values.Two:

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -90,7 +90,7 @@ function doSomething(value: Values) {
   });
 });
 
-it("with existing cases", () => {
+it("with existing cases (union type)", () => {
   shouldUpdateCodeFor({
     code: `type Values = "one" | "two" | "three";
 
@@ -110,6 +110,35 @@ function doSomething(value: Values) {
       $1
 `,
       position: new Position(10, 0),
+      name: "Create all cases"
+    }
+  });
+});
+
+it("with existing cases (enum)", () => {
+  shouldUpdateCodeFor({
+    code: `enum Values {
+  One,
+  Two,
+  Three
+}
+
+function doSomething(value: Values) {
+  switch (value) {
+    case Values.One:
+      doSomething();
+      break;
+
+    case Values.Three:
+      break;
+  }
+}`,
+    selection: Selection.cursorAt(10, 0),
+    expectedSnippet: {
+      code: `    case Values.Two:
+      $1
+`,
+      position: new Position(14, 0),
       name: "Create all cases"
     }
   });

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -26,8 +26,9 @@ function doSomething(value: Values) {
       $2
 
     case "three":
-      $3`,
-      position: new Position(4, 0),
+      $3
+`,
+      position: new Position(5, 0),
       name: "Create all cases"
     }
   });
@@ -55,8 +56,9 @@ function doSomething(value: Values) {
       $2
 
     case Values.Three:
-      $3`,
-      position: new Position(8, 0),
+      $3
+`,
+      position: new Position(9, 0),
       name: "Create all cases"
     }
   });
@@ -80,6 +82,7 @@ function doSomething(value: Values) {
 
     case "three":
       $3
+
   `,
       position: new Position(3, 18),
       name: "Create all cases"

--- a/src/create-switch-cases/create-switch-cases.test.ts
+++ b/src/create-switch-cases/create-switch-cases.test.ts
@@ -19,9 +19,14 @@ function doSomething(value: Values) {
 }`,
     selection: Selection.cursorAt(4, 0),
     expectedSnippet: {
-      code: `case "one":$1
-    case "two":$2
-    case "three":$3`,
+      code: `case "one":
+      $1
+
+    case "two":
+      $2
+
+    case "three":
+      $3`,
       position: new Position(4, 0),
       name: "Create all cases"
     }
@@ -43,9 +48,14 @@ function doSomething(value: Values) {
 }`,
     selection: Selection.cursorAt(8, 0),
     expectedSnippet: {
-      code: `case Values.One:$1
-    case Values.Two:$2
-    case Values.Three:$3`,
+      code: `case Values.One:
+      $1
+
+    case Values.Two:
+      $2
+
+    case Values.Three:
+      $3`,
       position: new Position(8, 0),
       name: "Create all cases"
     }
@@ -62,9 +72,14 @@ function doSomething(value: Values) {
     selection: Selection.cursorAt(3, 18),
     expectedSnippet: {
       code: `
-    case "one":$1
-    case "two":$2
-    case "three":$3
+    case "one":
+      $1
+
+    case "two":
+      $2
+
+    case "three":
+      $3
   `,
       position: new Position(3, 18),
       name: "Create all cases"

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -37,22 +37,23 @@ class CreateSwitchCases implements Modification {
   }
 
   execute(update: Update) {
+    if (!t.isSelectablePath(this.path)) return;
+    const selection = Selection.fromPath(this.path);
     const discriminantPath = this.path.get("discriminant");
     // TODO: is it OK or should it be resolved before?
     if (!t.isSelectablePath(discriminantPath)) return;
 
-    // TODO: find correct position
     // TODO: indentation
     // TODO: add stops in snippet
     // TODO: restrict usage so it doesn't execute if no case
     const indentation = "    ";
-    const selection = Selection.fromPath(discriminantPath);
-    const type = this.typeChecker.getLiteralValuesAt(selection.start);
+    const discriminantStart = Selection.fromPath(discriminantPath).start;
+    const type = this.typeChecker.getLiteralValuesAt(discriminantStart);
     const cases = type.map(value => `${indentation}case ${value}:`).join("\n");
 
     update({
       code: `\n${cases}`,
-      position: new Position(4, 0),
+      position: selection.end.putAtPreviousLine().putAtStartOfLine(),
       name: `Create all cases`
     });
   }

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -62,17 +62,9 @@ class CreateSwitchCases implements Modification {
       discriminantStart
     );
 
-    const NO_VALUE = null;
-    const existingCases = this.path.node.cases
-      .map(caseNode => {
-        try {
-          // @ts-ignore It's not typed, so let's try/catch to be safe 🤠
-          return caseNode.test.extra.raw;
-        } catch {
-          return NO_VALUE;
-        }
-      })
-      .filter(value => value !== NO_VALUE);
+    const existingCases = this.path.node.cases.map(caseNode =>
+      t.print(caseNode.test)
+    );
 
     return casesToGenerate
       .filter(value => !existingCases.includes(value))

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -67,7 +67,7 @@ class CreateSwitchCases implements Modification {
             this.oneLevelIndentation}$${index + 1}\n`
       )
       .join("\n")
-      .trim();
+      .trimEnd();
   }
 
   protected get indentation(): string {
@@ -101,7 +101,7 @@ class CreateOneLineSwitchCases extends CreateSwitchCases {
   }
 
   protected get cases(): string {
-    return `\n${this.indentation}${super.cases}\n${this.switchBaseIndentation}`;
+    return `\n${super.cases}\n${this.switchBaseIndentation}`;
   }
 
   protected get position(): Position {

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -48,11 +48,12 @@ class CreateSwitchCases implements Modification {
     const discriminantPath = this.path.get("discriminant");
     if (!t.isSelectablePath(discriminantPath)) return;
 
-    // TODO: add stops in snippet
     // TODO: restrict usage so it doesn't execute if no case
     const discriminantStart = Selection.fromPath(discriminantPath).start;
     const type = this.typeChecker.getLiteralValuesAt(discriminantStart);
-    const cases = type.map(value => `${indentation}case ${value}:`).join("\n");
+    const cases = type
+      .map((value, index) => `${indentation}case ${value}:$${index + 1}`)
+      .join("\n");
 
     update({
       code: `\n${cases}`,

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -1,4 +1,4 @@
-import { Code, Selection, Position } from "../editor";
+import { Code, Selection } from "../editor";
 import { Modification, NoModification, Update } from "../modification";
 import * as t from "../ast";
 import { TypeChecker } from "../create-function-with-types/type-checker";

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -56,7 +56,7 @@ class CreateSwitchCases implements Modification {
     if (cases.length === 0) return;
 
     update({
-      code: `\n${cases}`,
+      code: `${cases.trimStart()}`,
       position: selection.end.putAtPreviousLine().putAtStartOfLine(),
       name: `Create all cases`
     });

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -48,12 +48,12 @@ class CreateSwitchCases implements Modification {
     const discriminantPath = this.path.get("discriminant");
     if (!t.isSelectablePath(discriminantPath)) return;
 
-    // TODO: restrict usage so it doesn't execute if no case
     const discriminantStart = Selection.fromPath(discriminantPath).start;
     const type = this.typeChecker.getLiteralValuesAt(discriminantStart);
     const cases = type
       .map((value, index) => `${indentation}case ${value}:$${index + 1}`)
       .join("\n");
+    if (cases.length === 0) return;
 
     update({
       code: `\n${cases}`,

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -16,7 +16,6 @@ function createSwitchCases(
   t.traverseCode(code, {
     SwitchStatement(path) {
       if (!selection.isInsidePath(path)) return;
-      // if (t.isDeclared(path.node.callee, path)) return;
 
       result = new CreateSwitchCases(path, code, logger);
     }
@@ -39,14 +38,18 @@ class CreateSwitchCases implements Modification {
   execute(update: Update) {
     if (!t.isSelectablePath(this.path)) return;
     const selection = Selection.fromPath(this.path);
+
+    const INDENTATION_CHAR = " ";
+    const INDENTATION_WIDTH = 2;
+    const indentation = INDENTATION_CHAR.repeat(
+      selection.start.character + INDENTATION_WIDTH
+    );
+
     const discriminantPath = this.path.get("discriminant");
-    // TODO: is it OK or should it be resolved before?
     if (!t.isSelectablePath(discriminantPath)) return;
 
-    // TODO: indentation
     // TODO: add stops in snippet
     // TODO: restrict usage so it doesn't execute if no case
-    const indentation = "    ";
     const discriminantStart = Selection.fromPath(discriminantPath).start;
     const type = this.typeChecker.getLiteralValuesAt(discriminantStart);
     const cases = type.map(value => `${indentation}case ${value}:`).join("\n");

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -1,0 +1,59 @@
+import { Code, Selection, Position } from "../editor";
+import { Modification, NoModification, Update } from "../modification";
+import * as t from "../ast";
+import { TypeChecker } from "../create-function-with-types/type-checker";
+import { Logger, NoopLogger } from "../logger";
+
+export { createSwitchCases };
+
+function createSwitchCases(
+  code: Code,
+  selection: Selection,
+  logger: Logger = new NoopLogger()
+): Modification {
+  let result: Modification = new NoModification();
+
+  t.traverseCode(code, {
+    SwitchStatement(path) {
+      if (!selection.isInsidePath(path)) return;
+      // if (t.isDeclared(path.node.callee, path)) return;
+
+      result = new CreateSwitchCases(path, code, logger);
+    }
+  });
+
+  return result;
+}
+
+class CreateSwitchCases implements Modification {
+  private typeChecker: TypeChecker;
+
+  constructor(
+    private path: t.NodePath<t.SwitchStatement>,
+    code: Code,
+    logger: Logger
+  ) {
+    this.typeChecker = new TypeChecker(code, logger);
+  }
+
+  execute(update: Update) {
+    const discriminantPath = this.path.get("discriminant");
+    // TODO: is it OK or should it be resolved before?
+    if (!t.isSelectablePath(discriminantPath)) return;
+
+    // TODO: find correct position
+    // TODO: indentation
+    // TODO: add stops in snippet
+    // TODO: restrict usage so it doesn't execute if no case
+    const indentation = "    ";
+    const selection = Selection.fromPath(discriminantPath);
+    const type = this.typeChecker.getLiteralValuesAt(selection.start);
+    const cases = type.map(value => `${indentation}case ${value}:`).join("\n");
+
+    update({
+      code: `\n${cases}`,
+      position: new Position(4, 0),
+      name: `TODO: find a name`
+    });
+  }
+}

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -61,20 +61,29 @@ class CreateSwitchCases implements Modification {
     const type = this.typeChecker.getLiteralValuesAt(discriminantStart);
 
     return type
-      .map((value, index) => `${this.indentation}case ${value}:$${index + 1}`)
+      .map(
+        (value, index) =>
+          `${this.indentation}case ${value}:\n${this.indentation +
+            this.oneLevelIndentation}$${index + 1}\n`
+      )
       .join("\n")
-      .trimStart();
+      .trim();
   }
 
   protected get indentation(): string {
-    const INDENTATION_WIDTH = 2;
+    return this.switchBaseIndentation + this.oneLevelIndentation;
+  }
 
-    return this.INDENTATION_CHAR.repeat(
-      this.selection.start.character + INDENTATION_WIDTH
-    );
+  protected get switchBaseIndentation(): string {
+    return this.INDENTATION_CHAR.repeat(this.selection.start.character);
+  }
+
+  protected get oneLevelIndentation(): string {
+    return this.INDENTATION_CHAR.repeat(this.INDENTATION_WIDTH);
   }
 
   protected INDENTATION_CHAR = " ";
+  protected INDENTATION_WIDTH = 2;
 
   protected get position(): Position {
     return this.selection.end.putAtPreviousLine().putAtStartOfLine();
@@ -92,11 +101,7 @@ class CreateOneLineSwitchCases extends CreateSwitchCases {
   }
 
   protected get cases(): string {
-    const closingBraceIndentation = this.INDENTATION_CHAR.repeat(
-      this.selection.start.character
-    );
-
-    return `\n${this.indentation}${super.cases}\n${closingBraceIndentation}`;
+    return `\n${this.indentation}${super.cases}\n${this.switchBaseIndentation}`;
   }
 
   protected get position(): Position {

--- a/src/create-switch-cases/create-switch-cases.ts
+++ b/src/create-switch-cases/create-switch-cases.ts
@@ -53,7 +53,7 @@ class CreateSwitchCases implements Modification {
     update({
       code: `\n${cases}`,
       position: new Position(4, 0),
-      name: `TODO: find a name`
+      name: `Create all cases`
     });
   }
 }

--- a/src/create-switch-cases/index.ts
+++ b/src/create-switch-cases/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-switch-cases";

--- a/src/editor/position.ts
+++ b/src/editor/position.ts
@@ -47,6 +47,10 @@ class Position {
     return new Position(this.line, 999999999);
   }
 
+  putAtPreviousLine(): Position {
+    return new Position(this.line - 1, this.character);
+  }
+
   putAtNextLine(): Position {
     return new Position(this.line + 1, this.character);
   }

--- a/src/editor/selection.ts
+++ b/src/editor/selection.ts
@@ -31,7 +31,11 @@ class Selection {
   }
 
   get isMultiLines(): boolean {
-    return !this.start.isSameLineThan(this.end);
+    return !this.isOneLine;
+  }
+
+  get isOneLine(): boolean {
+    return this.start.isSameLineThan(this.end);
   }
 
   get height(): number {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ class ActionProvider implements vscode.CodeActionProvider {
 
         if (modificationName === null) return null;
 
-        const title = `🔮 ${modificationName}`;
+        const title = `${modificationName} 🔮`;
         const action = new vscode.CodeAction(title);
         action.command = {
           command: id,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { createFunction } from "./create-function";
 import { createFunctionWithTypes } from "./create-function-with-types";
 import { createVariable } from "./create-variable";
 import { createClass } from "./create-class";
+import { createSwitchCases } from "./create-switch-cases";
 import { Position, Selection, Code } from "./editor";
 import { Modification } from "./modification";
 
@@ -29,6 +30,11 @@ const COMMANDS = [
   {
     id: "hocusPocus.createClass",
     run: createClass,
+    languages: ALL_LANGUAGES
+  },
+  {
+    id: "hocusPocus.createSwitchCases",
+    run: createSwitchCases,
     languages: ALL_LANGUAGES
   }
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.7.4":
+"@babel/generator@7.7.4", "@babel/generator@^7.4.0", "@babel/generator@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369"
   integrity sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==


### PR DESCRIPTION
Create all missing cases of a switch statement made over an union type or an enum.

Very convenient when you need to generate a switch statement to handle each scenario. If some cases are already present, it will complete the remaining ones.

Thanks @fabien0102 for suggesting this one!

![create-switch-cases](https://user-images.githubusercontent.com/1094774/95536593-5be0f000-09b9-11eb-9e10-274e9818602d.gif)
